### PR TITLE
Fixed bug with Owners updating incorrectly

### DIFF
--- a/pet-adoption-frontend/src/pages/settings.jsx
+++ b/pet-adoption-frontend/src/pages/settings.jsx
@@ -156,7 +156,7 @@ export default function HomePage() {
 
     // Only validate zip if userType is Owner
     if (updatedValuesRef.current.userType === 'Owner') {
-      if (!zipInvalid) {
+      if (zipInvalid) {
         return; // Exit if zip is invalid
       }
     }


### PR DESCRIPTION
System was only attempting to update when zip code value was invalid, when it should've been only when valid